### PR TITLE
Created WikiArticleHelper module

### DIFF
--- a/Google_Recommended_Wikipedia_Pages.py
+++ b/Google_Recommended_Wikipedia_Pages.py
@@ -164,36 +164,6 @@ def IsWikipageAppropriate(title, hyperlink):
         print("The Wikipedia page is OK to recommend.")
         return True, resultRow
 
-#Returns a list of html reference tag ids
-#
-#accepts: bs4 Tag as SummaryContainer
-#
-def GetReferencesFromSummaryContainer(SummaryContainer):
-    found = []
-    for child in SummaryContainer.children:
-        if isinstance(child, element.Tag):
-
-            #Each article summary ends with this table so we don't want
-            #any <p> tags after this
-            if child.has_attr('id') and child['id'] == "toc":
-                return found
-
-            #Each article container has a blank <p> tag that we want to ignore
-            if child.has_attr('class') and "mw-empty-elt" in child['class']:
-                continue
-
-            #Our summary paragraph(s)
-            if child.name == 'p':
-                references = child.find_all('sup')
-                for ref in references: 
-                    found.extend([tag['href'][1:] for tag in ref.find_all('a')])
-
-
-    #We should have returned our list already, so if we get this far
-    #something is probably wrong with the structure of our soup article
-    return []
-
-
 #Builds a dictionary of systems for 
 def BuildArticleStructure(url):
     pass

--- a/Google_Recommended_Wikipedia_Pages.py
+++ b/Google_Recommended_Wikipedia_Pages.py
@@ -194,38 +194,10 @@ def GetReferencesFromSummaryContainer(SummaryContainer):
     return []
 
 
-#Returns a list of references listed in the summary of a
-#wikipedia article
-#
-#accepts a url as string
-#
-def GetReferenceDataFromArticle(url):
-    print("Getting summary from article: ", url)#TODO remove
-    soup = soupStructure(url)
+#Builds a dictionary of systems for 
+def BuildArticleStructure(url):
+    pass
 
-    #The wiki html structure does not explicitly define the summary paragraphs so we
-    #have to find the <p> tags which are direct descendents of the <div> below id#mw-content-text
-    summary_container = soup.find(id="mw-content-text")
-    refs = GetReferencesFromSummaryContainer(list(summary_container.children)[0])
-    
-    ExtractedReferences = []
-    
-    for ref_id in refs:
-        if ref_id == "wiki/Wikipedia:Citation_needed":
-            print("Missing citation ")
-
-        FullReference = {}
-        ref = soup.find(id=ref_id)
-        if not ref:
-            print("Error finding reference with HTML ID: ", ref_id)
-            continue
-        LinkTags = ref.find_all('a')
-
-        for tag in LinkTags:
-            if tag.has_attr('class'):
-                ExtractedReferences.append({'name': tag.string, 'link': tag['href']})
-        
-    return ExtractedReferences
 
 # datatsetFileName = input(
 #     "Enter the name of the dataset csv file without any sufix:")
@@ -281,7 +253,7 @@ with open(datatsetFileName + '.csv', 'w') as fw:
             if not flag:
                 continue
 
-            ReferenceData = GetReferenceDataFromArticle(recommendedURL)
+            
 
             #TODO Pass reference data to MicrosoftResearchAPI
 

--- a/WikiArticleHelper.py
+++ b/WikiArticleHelper.py
@@ -1,0 +1,114 @@
+import WikipediaScrapingLibrary
+from bs4 import element
+import unittest
+import re
+
+#TODO implement caching one article for successive calls to 
+#getReferenceData and getPrerequisiteData
+#
+cache_url = None
+cache = None
+
+#Returns a list of summary paragraphs as bs4 tags 
+#
+#accepts: bs4 object for the article
+#
+def getSummaryParagraphs(articleSoup):
+    found = []
+
+    summary_container = articleSoup.find(id="mw-content-text")
+    if summary_container == None:
+        return found
+
+    for child in list(summary_container)[0].children:
+        
+        if isinstance(child, element.Tag):
+
+            #Some articles have a <p> tag that only serves to hold coordinates
+            #So we want to skip that one
+            if child.find_all(id='coordinates'):
+                continue
+
+            #The only common identifier shared by summary paragraphs is that they contain
+            #<a> tags
+            #So that's what were going with
+            if child.name == 'p' and len(list(child.find_all("a"))) > 0:
+                found.append(child)
+
+
+            #There is not a consistent identifier for the TOC so we just get paragraphs
+            #until we get to a different tag
+            elif len(found) > 0:
+                return found
+            
+
+    #We should have returned our list already, so if we get this far
+    #something is probably wrong with the structure of our soup article
+    return []
+
+
+##
+#Returns a list of prerequisite article urls as strings 
+#
+#
+#Accepts url as string
+##
+def getPrerequisiteDataFromArticle(url):
+    print("Getting summary from article: ", url)
+
+    soup = WikipediaScrapingLibrary.soupStructure(url)
+    
+    prerequisites = []
+    
+    summary_paragraphs = getSummaryParagraphs(soup)
+
+    for paragraph in summary_paragraphs:
+        for link in paragraph.find_all('a'):
+            if link.has_attr('href') and '#cite_note' not in link['href']:
+                prerequisites.append('https://en.wikipedia.org' + link['href'])
+    
+    if len(prerequisites) == 0:
+        print("Found no prerequisites, flagging article as abnormality: ", url)#TODO implement logging
+
+    return prerequisites
+
+#Returns a list of references listed in the summary of a
+#wikipedia article
+#
+#accepts a url as string
+#
+def GetReferenceDataFromArticle(url):
+    print("Getting summary from article: ", url)#TODO remove
+    soup = WikipediaScrapingLibrary.soupStructure(url)
+
+    #The wiki html structure does not explicitly define the summary paragraphs so we
+    #have to find the <p> tags which are direct descendents of the <div> below id#mw-content-text
+    summary_paragraphs = getSummaryParagraphs(soup)
+    
+    ExtractedReferences = []
+    ref_section = soup.find('ol', {'class':"references"})
+    
+    if not ref_section:
+        print("Trouble finding reference section, flagging")#TODO implement logging
+        return []
+
+    found = []
+
+    for paragraph in summary_paragraphs:
+        #TODO Do we want to take into account summary references which are marked as 'wiki/Wikipedia:Citation_needed'?
+        for link in paragraph.find_all('a', {'href': re.compile(r'#cite_note.+')}):
+            ref = ref_section.find(id=link['href'][1:])
+            
+            try:
+                found.append((ref.find('a', {'class': re.compile(r'external')})['href'], ref.find('cite').text))
+            except Exception as e:
+                print("Error getting citation information from: ", url)#TODO Implement Logging
+            
+    return found
+
+#This is just to test this module on a variety of wiki articles to ensure that 
+#it works in 99% of cases
+if __name__ == '__main__':
+    print(GetReferenceDataFromArticle('https://en.wikipedia.org/wiki/Ford_Motor_Company'))
+    #print(len(getSummaryParagraphs(WikipediaScrapingLibrary.soupStructure('https://en.wikipedia.org/wiki/Ford_Motor_Company'))) == 3)
+    #print(len(getSummaryParagraphs(WikipediaScrapingLibrary.soupStructure('https://google.com'))) == 0)


### PR DESCRIPTION
This module serves to grab references or prerequisite articles from the summary paragraphs of a given wiki article. Also moved some functions out of the google search module due to deprecation of that system.